### PR TITLE
Fix Albers Equal Area Conic Projection (aea) to work with PROJ5/PROJ6

### DIFF
--- a/vresutils/shapes.py
+++ b/vresutils/shapes.py
@@ -62,7 +62,7 @@ def points(poly):
 def area(geom):
     return reproject(geom).area
 
-def reproject(geom, fr=pyproj.Proj(proj='longlat'), to=pyproj.Proj(proj='aea')):
+def reproject(geom, fr=pyproj.Proj(proj='longlat'), to=pyproj.Proj(proj='aea', lat_1=33., lat_2=72.)):
     reproject_pts = partial(pyproj.transform, fr, to)
     return transform(reproject_pts, geom)
 


### PR DESCRIPTION
As noted in pypsa/pypsa-eur#72 using `pyproj>=2` (not using PROJ4 but PROJ5 or PROJ6) causes trouble at https://github.com/FRESNA/vresutils/blob/20c2364fe85502b2009aa36b9b58b7b7f271788a/vresutils/shapes.py#L65-L67

for the Albers Equal Area Conic projection (https://proj.org/operations/projections/aea.html)
```python
import pyproj
pyproj.Proj(proj='aea')
```
```
CRSError: Invalid projection: +proj=aea +type=crs: 
(Internal Proj Error: proj_create: Error -21: conic lat_1 = -lat_2)
```

It seems that with the new PROJ versions, it is necessary to set the properties `lat_1` and `lat_2` for the projection `aea` which can be understood as focus area of the projection (and they cannot be the same! Weirdly default values are both 0...):

> This conic projection uses two standard parallels to reduce some of the distortion of a projection with one standard parallel. Although neither shape nor linear scale is truly correct, the distortion of these properties is minimized in the region between the standard parallels. (https://desktop.arcgis.com/en/arcmap/latest/map/projections/albers-equal-area-conic.htm)

So now we should state instead the confidence region (e.g. Europe by default):

```python
import pyproj
pyproj.Proj(proj='aea', lat_1=33., lat_2=72.)
```

This change makes no difference in the load time series calculation
```python
from vresutils.load import timeseries_opsd
```
where this error originally occurs.
