### PR TITLE
graph: export voronoi shapes as plain list not np.array

### DIFF
--- a/vresutils/graph.py
+++ b/vresutils/graph.py
@@ -483,7 +483,7 @@ def voronoi_partition_pts(points, outline, no_multipolygons=False):
 
     Returns
     -------
-    polygons : N - ndarray[dtype=Polygon|MultiPolygon]
+    polygons : list[dtype=Polygon|MultiPolygon]
     """
 
     points = np.asarray(points)
@@ -525,9 +525,7 @@ def voronoi_partition_pts(points, outline, no_multipolygons=False):
             return poly
         polygons = [demultipolygon(poly) for poly in polygons]
 
-    polygons_arr = np.empty((len(polygons),), 'object')
-    polygons_arr[:] = polygons
-    return polygons_arr
+    return polygons
 
 def voronoi_partition(G, outline):
     """


### PR DESCRIPTION
due to deprecation warning for shapely 2.0 in shapely 1.8

https://github.com/Toblerity/Shapely/blob/462de3aa7a8bbd80408762a2d5aaf84b04476e4d/CHANGES.txt#L108